### PR TITLE
Document togglz:inactive

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ Add an instance of com.github.heneke.thymeleaf.togglz.TogglzDialect to your Thym
 <div togglz:active="YOUR_FEATURE_NAME">
     content only visible if feature is active
 </div>
+<div togglz:inactive="YOUR_FEATURE_NAME">
+    content only visible if feature is <b>inactive</b>
+</div>
 ```
 
 to show/hide the markup container based on feature state.
@@ -27,6 +30,9 @@ Until recently, the expression processor for togglz:active did not support expre
 ````html
 <div togglz:active="'YOUR_FEATURE_NAME'">
     content only visible if feature is active
+</div>
+<div togglz:inactive="'YOUR_FEATURE_NAME'">
+    content only visible if feature is <b>inactive</b>
 </div>
 ```
 


### PR DESCRIPTION
I had to dig into the code to see that this was an option, so it would probably help to call this out in the main usage examples.